### PR TITLE
Fix NameError in __init__.py

### DIFF
--- a/pycrk/__init__.py
+++ b/pycrk/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import annotations
 
 import logging
 import os


### PR DESCRIPTION
 (partial fix for #2 )

Not sure of the details of either the cause or the fix. 

On py 3.10, I get "
```
..../__init__.py", line 31, in <module>
  def _find_changes(original: os.PathLike, patched: os.PathLike) ->
List[Change]:
 NameError: name 'Change' is not defined
```

Fix from #python IRC